### PR TITLE
Add budo to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "browserify": "^14.1.0",
     "browserify-shim": "^3.8.13",
+    "budo": "^10.0.3",
     "chai": "^3.5.0",
     "coffeeify": "^2.1.0",
     "electron": "^1.4.15",


### PR DESCRIPTION
The `npm start` script requires `budo` to be installed. I added it to the dev dependencies, since it's not documented that it should be installed globally 😄 