### PR TITLE
Add option to show out-of-crop parts of image

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ cropper.on('change', function(crop) {
 | `maxArea` | Number | e.g. `0.8` means max 80% of the area will be covered by the image. This makes for smoth transitions between wide and tall image formats. |
 | `zoomStep` | Number | e.g. `1.25` means every zoom will enlarge the preview by 25%. |
 | `actions` | Object | {pan, zoomOnDoubleClick, resize } Allowed user interactions. By default they are all set to `true`. |
+| `showSurroundingImage` | String | {always, never, panning } Shows the uncropped part of the image. By default set to `never`. |
+| `surroundingImageOpacity` | Number | {0.0 - 1.0} Sets the opacity when showing the uncropped part of the image. By default set to `0.2`. |
 
 ### HTML
 

--- a/examples/css/srcissors.css
+++ b/examples/css/srcissors.css
@@ -95,10 +95,13 @@
   transition: opacity 0.5s;
 }
 
+.crop-outline img {
+  width: 100%;
+}
+
 .crop-outline--active {
   opacity: 1;
 }
-
 
 /* Zoom Controls */
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -55,7 +55,8 @@
           url: "/images/diagonal.jpg",
           fixedWidth: 300,
           minRatio: 1 / 1.5,
-          maxRatio: 1.5 / 1
+          maxRatio: 1.5 / 1,
+          showSurroundingImage: 'always'
         });
 
         crop.setCrop({

--- a/src/crop.coffee
+++ b/src/crop.coffee
@@ -7,7 +7,8 @@ module.exports = class Crop
   constructor: ({
       @arena, @view, @img, @outline, url, @fixedWidth, @fixedHeight,
       @minViewWidth, @minViewHeight, @minViewRatio, @maxViewRatio, crop
-      zoomStep, maxArea, @actions, @minResolution
+      zoomStep, maxArea, @actions, @minResolution, @surroundingImageOpacity,
+      showSurroundingImage
     }) ->
 
       # CSS classes
@@ -38,10 +39,13 @@ module.exports = class Crop
       # be more reliable.
       @maxArea = (@arenaWidth * @arenaHeight) * maxArea if maxArea
 
+      @setSurroundingImageVisibility(showSurroundingImage) if @outline
+
       @preview = new Preview
         onReady: @onPreviewReady
         img: @img
         outline: @outline
+        opacity: @surroundingImageOpacity
 
       @setImage(url)
 
@@ -59,6 +63,20 @@ module.exports = class Crop
     @initializeReadyState()
     @view.addClass(@loadingCssClass)
     @preview.setImage({ url })
+
+  
+  setSurroundingImageVisibility: (visibility) ->
+    # visibility: always|panning|never
+    # override opacity in crop-outline--active css class
+    @surroundingImageOpacity = parseFloat(@surroundingImageOpacity || 0.2)
+
+    if visibility == 'always'
+      @outline.css('opacity', 1.0)
+    else if visibility == 'panning'
+      @outline.css('opacity', null)
+    else # 'never' default
+      @outline.css('opacity', 0)
+      @surroundingImageOpacity = 0
 
 
   reset: ->

--- a/src/preview.coffee
+++ b/src/preview.coffee
@@ -1,6 +1,8 @@
+$ = require('jquery')
+
 module.exports = class Preview
 
-  constructor: ({ @onReady, @img, @outline }) ->
+  constructor: ({ @onReady, @img, @opacity, @outline }) ->
     @x = @y = 0
     @width = @height = 0
 
@@ -16,6 +18,13 @@ module.exports = class Preview
 
   setImage: ({ @url }) ->
     @img.attr('src', @url)
+    @setBackgroundImage({url: @url}) if @outline
+
+  
+  setBackgroundImage: ({ url }) ->
+    if @opacity > 0
+      bg_img = $('<img>').css(opacity: @opacity).attr('src', url)
+      @outline.append(bg_img)
 
 
   reset: ->
@@ -24,7 +33,7 @@ module.exports = class Preview
     @width = @height = 0
     @img.attr('src', '')
     @img.css(width: '', height: '', transform: '')
-    @outline.css(transform: '') if @outline
+    @outline.css(transform: '').html('') if @outline
 
 
   setWidth: (width) ->

--- a/src/srcissors.coffee
+++ b/src/srcissors.coffee
@@ -5,7 +5,8 @@ module.exports = window.srcissors =
 
   new: ({
     arena, url, fixedWidth, fixedHeight, minWidth, minHeight,
-    minRatio, maxRatio, maxArea, zoomStep, crop, actions, minResolution
+    minRatio, maxRatio, maxArea, zoomStep, crop, actions, minResolution,
+    surroundingImageOpacity, showSurroundingImage
   }) ->
     arena = $(arena)
     view = arena.find('.crop-view')
@@ -36,6 +37,8 @@ module.exports = window.srcissors =
       view: view # {jQuery Element}
       img: img # {jQuery Element}
       outline: outline # {jQuery Element or undefined}
+      showSurroundingImage: showSurroundingImage # {String} always|panning|never
+      surroundingImageOpacity: surroundingImageOpacity # {Number} e.g. in the 0.0 - 1.0 range
       fixedWidth: fixedWidth # {Number} e.g. 300
       fixedHeight: fixedHeight # {Number} e.g. 500
       minViewWidth: minWidth # {Number} e.g. 100

--- a/test/specs/srcissors_spec.coffee
+++ b/test/specs/srcissors_spec.coffee
@@ -4,6 +4,7 @@ srcissors = require('../../src/srcissors')
 template = """
   <div class="crop-arena">
     <div class="crop-view">
+      <div class="crop-outline"></div>
 
       <!-- image -->
       <div class="crop-preview"></div>
@@ -200,3 +201,91 @@ describe 'srcissors', ->
           height: 300
 
         done()
+    
+  describe 'with surrounding image always enabled', ->
+
+    beforeEach (done) ->
+      @arena = $(template)
+      @arena.css(width: 100, height: 100)
+      $(document.body).append(@arena)
+
+      # Crop a 400x300 image
+      @crop = srcissors.new
+        arena: @arena
+        url: 'base/test/images/diagonal.jpg'
+        showSurroundingImage: 'always'
+        surroundingImageOpacity: 0.4
+      @crop.on 'ready', done
+
+
+    afterEach ->
+      @arena.remove()
+
+
+    it 'has initialized the crop outline background correctly', ->
+      outline = @arena.find('.crop-outline')
+      bgImg = outline.find('img')
+
+      expect(bgImg.length).to.equal(1)
+      expect(bgImg.get(0).style.opacity).to.equal('0.4')
+      expect(outline.get(0).style.opacity).to.equal('1')
+
+
+    it 'cleans up the crop outline when setting a different image', ->
+      @crop.setImage('base/test/images/berge.jpg')
+
+      bgImg = @arena.find('.crop-outline img')
+      expect(bgImg.length).to.equal(1)
+
+  describe 'with surrounding image enabled when panning', ->
+
+    beforeEach (done) ->
+      @arena = $(template)
+      @arena.css(width: 100, height: 100)
+      $(document.body).append(@arena)
+
+      # Crop a 400x300 image
+      @crop = srcissors.new
+        arena: @arena
+        url: 'base/test/images/diagonal.jpg'
+        showSurroundingImage: 'panning'
+      @crop.on 'ready', done
+
+
+    afterEach ->
+      @arena.remove()
+
+
+    it 'has initialized the crop outline background correctly', ->
+      outline = @arena.find('.crop-outline')
+      bgImg = outline.find('img')
+
+      expect(bgImg.length).to.equal(1)
+      expect(bgImg.get(0).style.opacity).to.equal('0.2')
+      expect(outline.get(0).style.opacity).to.equal('')
+
+
+  describe 'with surrounding image disabled by default', ->
+
+    beforeEach ->
+      @arena = $(template)
+      @arena.css(width: 100, height: 100)
+      $(document.body).append(@arena)
+
+
+    afterEach ->
+      @arena.remove()
+
+
+    it 'omits the background image without surrounding image config', (done) ->
+      @crop = srcissors.new
+        arena: @arena
+        url: 'base/test/images/diagonal.jpg'
+      @crop.on 'ready', done
+
+      outline = @arena.find('.crop-outline')
+      bgImg = outline.find('img')
+
+      expect(bgImg.length).to.equal(0)
+      expect(outline.get(0).style.opacity).to.equal('0')
+    


### PR DESCRIPTION
How it works:

![preview-opacity](https://cloud.githubusercontent.com/assets/234051/25702365/fac773bc-30d0-11e7-9435-eff087774c7e.gif)

Two new config options were added, `surroundingImageOpacity` and `showSurroundingImage`. Possible values for the later are: `never|always|panning`, the default it `never` to keep the current behavior.

How to enable it:

```
var crop = srcissors.new({
      arena: $('.crop-arena'),
      url: "/images/diagonal.jpg",
      showSurroundingImage: 'always',
      surroundingImageOpacity: 0.2
});
```